### PR TITLE
[feat] added line numbers in code snippets for blog posts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -113,6 +113,18 @@
     @apply p-0 leading-3;
   }
 
+  .prose pre code {
+    counter-reset: sh-line-number;
+  }
+
+  .prose .sh__line::before {
+    counter-increment: sh-line-number 1;
+    content: counter(sh-line-number);
+    margin-right: 12px;
+    text-align: right;
+    color: #a4a4a4;
+  }
+
   .prose code span {
     @apply font-medium;
   }

--- a/components/mdx/code.tsx
+++ b/components/mdx/code.tsx
@@ -7,7 +7,7 @@ type CodeProps = {
 
 const Code = ({ children, className = '', ...props }: CodeProps) => {
   let codeHTML = highlight(children as string);
-  return <code dangerouslySetInnerHTML={{ __html: codeHTML }} />;
+  return <code dangerouslySetInnerHTML={{ __html: codeHTML }} {...props} />;
 };
 
 export default Code;

--- a/content/posts/binary-search.mdx
+++ b/content/posts/binary-search.mdx
@@ -80,46 +80,46 @@ _Only 8 steps!_ That's right, even with twice as many items, you only need one e
 </Callout>
 
 ```
-  const list = [1,5,7,8,9];
+const list = [1,5,7,8,9];
 
-  function binarySearch(arrayOfItems, item) {
-    // Low and high
-    // are supposed to keep a track of
-    // part of the list that will be searched.
-    let low = 0;
-    let high = arrayOfItems.length - 1;
+function binarySearch(arrayOfItems, item) {
+  // Low and high
+  // are supposed to keep a track of
+  // part of the list that will be searched.
+  let low = 0;
+  let high = arrayOfItems.length - 1;
 
-    // Unless the list hasn't been narrowed down to 1 element,
-    // keep on going in the loop
-    while (low <= high) {
-      // Checking the middle element
-      // Rounding down if low + high is not an even number
-      const mid = Math.floor((low + high) / 2);
-      const midElement = arrayOfItems[mid]; // The middle element
+  // Unless the list hasn't been narrowed down to 1 element,
+  // keep on going in the loop
+  while (low <= high) {
+    // Checking the middle element
+    // Rounding down if low + high is not an even number
+    const mid = Math.floor((low + high) / 2);
+    const midElement = arrayOfItems[mid]; // The middle element
 
-      // If the middle element is found, return it.
-      if (midElement === item) {
-        return midElement;
-      }
-      // If the middle element is greater than the item,
-      // update the high to middle element - 1
-      // in order to eliminate all the greater elements.
-      else if (midElement > item) {
-        high = mid - 1; // midElement was too high
-      }
-      // If the middle element is lesser than the item,
-      // update the low to middle element + 1
-      // in order to eliminate all the lower elements.
-      else {
-        low = mid + 1; // midElement was too low
-      }
+    // If the middle element is found, return it.
+    if (midElement === item) {
+      return midElement;
     }
-
-    return null
+    // If the middle element is greater than the item,
+    // update the high to middle element - 1
+    // in order to eliminate all the greater elements.
+    else if (midElement > item) {
+      high = mid - 1; // midElement was too high
+    }
+    // If the middle element is lesser than the item,
+    // update the low to middle element + 1
+    // in order to eliminate all the lower elements.
+    else {
+      low = mid + 1; // midElement was too low
+    }
   }
 
-  console.log(binarySearch(list, 9)); // 4 [index starts with 0]
-  console.log(binarySearch(list, 3)); // null [Not found]
+  return null
+}
+
+console.log(binarySearch(list, 9)); // 4 [index starts with 0]
+console.log(binarySearch(list, 3)); // null [Not found]
 ```
 
 <Callout type="warning">


### PR DESCRIPTION
**Why?**
UX enhancement for `<code>` tag to show the line numbers as per the code length.

**What?**
Added CSxS changes to add number according to the amount of lines of code.

**How?**
Added the CSS properties for `.sh__line` and resetted the counter in `pre` and `code` tags (see `app/globals.css`).

**Screenshot?**
![Screenshot 2025-03-22 at 1 27 39 AM](https://github.com/user-attachments/assets/22188e6b-1c99-48c4-a484-1f482f768c44)

> closes #9 