### PR TITLE
[feat] added copy icon in code snippets for blog posts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -97,7 +97,7 @@
     @apply font-serif text-3xl underline decoration-border/75 decoration-2 underline-offset-8;
   }
 
-  .title-sm {
+  .title-xl {
     @apply text-xl underline decoration-border/75 decoration-2 underline-offset-8 mt-6;
   }
 
@@ -107,6 +107,14 @@
 
   .prose code {
     @apply rounded-lg px-1 py-0.5;
+  }
+
+  .prose pre .code-language {
+    @apply text-foreground/50;
+  }
+
+  .prose pre .code-icon {
+    @apply size-4 text-foreground/50;
   }
 
   .prose pre code {

--- a/app/globals.css
+++ b/app/globals.css
@@ -114,7 +114,7 @@
   }
 
   .prose pre .code-icon {
-    @apply size-4 text-foreground/50;
+    @apply size-4 transition-all duration-300 ease-linear;
   }
 
   .prose pre code {

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -111,7 +111,7 @@ const IndividualPost = async ({ params: { slug } }: IndividualPostProps) => {
         </main>
 
         <div className='flex gap-2 my-6 flex-col'>
-          <p className='title-sm'>Tags</p>
+          <p className='title-xl'>Tags</p>
           <div className='flex flex-wrap gap-2 my-6'>
             {tags.map((tag) => (
               <Tag key={tag} tag={tag} />

--- a/components/mdx/code.tsx
+++ b/components/mdx/code.tsx
@@ -1,13 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Copy, CopyCheck, TerminalIcon } from 'lucide-react';
 import { highlight } from 'sugar-high';
+
+import { Button } from '../ui/button';
 
 type CodeProps = {
   children: React.ReactNode;
   className?: string;
+  title?: string;
 } & any;
 
-const Code = ({ children, className = '', ...props }: CodeProps) => {
+const Code = ({
+  children,
+  className = '',
+  title = 'Javascript',
+  ...props
+}: CodeProps) => {
+  const [copied, setCopied] = useState(false);
   let codeHTML = highlight(children as string);
-  return <code dangerouslySetInnerHTML={{ __html: codeHTML }} {...props} />;
+
+  const handleCopy = async (value: string) => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+
+    // After 2 seconds, revert the icon back to the copy icon
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div>
+      <div className='flex justify-between items-center pb-2'>
+        <div className='code-language flex pb-2 font-bold'>
+          <TerminalIcon className='mr-2 code-icon' />
+          <span className='text-xs'>{title}</span>
+        </div>
+
+        <Button
+          variant='ghost'
+          disabled={copied}
+          className='p-0 m-0 h-auto hover:bg-inherit hover:text-inherit disabled:opacity-100'
+          onClick={() => handleCopy(children)}
+        >
+          {copied ? (
+            <>
+              Copied!
+              <CopyCheck className='text-green-500' />
+            </>
+          ) : (
+            <Copy className='code-icon' />
+          )}
+        </Button>
+      </div>
+      <code dangerouslySetInnerHTML={{ __html: codeHTML }} {...props} />
+    </div>
+  );
 };
 
 export default Code;

--- a/components/mdx/code.tsx
+++ b/components/mdx/code.tsx
@@ -43,16 +43,16 @@ const Code = ({
         <Button
           variant='ghost'
           disabled={copied}
-          className='p-0 m-0 h-auto hover:bg-inherit hover:text-inherit disabled:opacity-100'
+          className='p-0 m-0 h-auto hover:bg-inherit hover:text-inherit disabled:opacity-100 transition-all duration-300 hover:scale-110 ease-linear transform'
           onClick={() => handleCopy(children)}
         >
           {copied ? (
             <>
               Copied!
-              <CopyCheck className='text-green-500' />
+              <CopyCheck className='text-green-500 transition-all duration-300 ease-linear' />
             </>
           ) : (
-            <Copy className='code-icon' />
+            <Copy className='code-icon transition-all duration-300 ease-linear' />
           )}
         </Button>
       </div>

--- a/components/mdx/code.tsx
+++ b/components/mdx/code.tsx
@@ -43,16 +43,16 @@ const Code = ({
         <Button
           variant='ghost'
           disabled={copied}
-          className='p-0 m-0 h-auto hover:bg-inherit hover:text-inherit disabled:opacity-100 transition-all duration-300 hover:scale-110 ease-linear transform'
+          className='p-0 m-0 h-auto hover:bg-inherit hover:text-inherit disabled:opacity-100 transition-all duration-300'
           onClick={() => handleCopy(children)}
         >
           {copied ? (
             <>
               Copied!
-              <CopyCheck className='text-green-500 transition-all duration-300 ease-linear' />
+              <CopyCheck className='code-icon text-green-500' />
             </>
           ) : (
-            <Copy className='code-icon transition-all duration-300 ease-linear' />
+            <Copy className='code-icon text-foreground/50' />
           )}
         </Button>
       </div>

--- a/components/posts.tsx
+++ b/components/posts.tsx
@@ -92,7 +92,7 @@ const Posts = ({ posts, className = '' }: PostsProps) => {
                 </div>
                 <div className='hidden md:flex justify-center items-center'>
                   {image && (
-                    <div className='relative w-36 h-36 overflow-hidden rounded-lg my-auto mx-0'>
+                    <div className='relative w-36 h-36 overflow-hidden rounded-lg my-auto mx-0 border-border border-2 dark:border-none'>
                       <Image
                         src={image}
                         alt={title ?? ''}

--- a/content/posts/binary-search.mdx
+++ b/content/posts/binary-search.mdx
@@ -79,7 +79,7 @@ _Only 8 steps!_ That's right, even with twice as many items, you only need one e
   Write a function binarySearch which takes a sorted array and an item. If the item is in the array, the function returns its position. Otherwise it will return null.
 </Callout>
 
-```
+```javascript
 const list = [1,5,7,8,9];
 
 function binarySearch(arrayOfItems, item) {

--- a/providers/index.tsx
+++ b/providers/index.tsx
@@ -21,7 +21,7 @@ const ToasterProvider = () => {
 
 const Providers = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
-    // Initial Analytics
+    // Initialize Analytics
     initAnalytics();
   }, []);
 


### PR DESCRIPTION
**Why?**
For enhancing UX by adding an option of copying the code in code snippets provided in blog posts.

**What?**
Added a `Copy` button  to copy the code along with the language of written code.

**How?**
1. Used [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) for copying the code (see `components/mdx/code.tsx:26`).
2. Also added transition for letting users know that they their code has been copied.

**GIF?**
![output](https://github.com/user-attachments/assets/4a03e3fa-d255-47e6-a414-aba55eaba353)

> Closes #11 
