### PR TITLE
feat(app): add tectonic theme styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,5 @@
+@import 'https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=Space+Grotesk:wght@300;500;700&display=swap';
+@import 'https://fonts.cdnfonts.com/css/rage-italic';
 @import 'tailwindcss';
 @plugin '@tailwindcss/typography';
 @plugin 'tailwindcss-animate';
@@ -54,6 +56,19 @@
 
   --color-secondary: hsl(var(--secondary));
   --color-secondary-foreground: hsl(var(--secondary-foreground));
+
+  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-rage: 'Rage Italic', cursive;
+
+  --color-obsidian: #050505;
+  --color-tectonic: #00d1ff;
+  --color-slab: #0a0a0a;
+  --color-fracture: rgb(0 209 255 / 10%);
+}
+
+.font-rage {
+  font-family: 'Rage Italic', cursive !important;
 }
 
 /*
@@ -158,7 +173,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans antialiased selection:bg-tectonic selection:text-obsidian;
   }
 
   .-h-screen-navbar {
@@ -219,5 +234,85 @@
 
   .header-bg {
     @apply backdrop-blur-sm supports-backdrop-filter:bg-background/60 bg-background/75;
+  }
+}
+
+@layer components {
+  .tectonic-border {
+    @apply border border-white/5 relative overflow-hidden transition-colors duration-300;
+  }
+
+  .tectonic-glow {
+    @apply absolute inset-0 opacity-0 transition-opacity duration-500 pointer-events-none;
+
+    background: radial-gradient(
+      500px circle at var(--x, 50%) var(--y, 50%),
+      rgb(0 209 255 / 6%) 0%,
+      transparent 70%
+    );
+  }
+
+  .tectonic-border:hover .tectonic-glow {
+    @apply opacity-100;
+  }
+
+  .slab-shadow {
+    box-shadow: 0 20px 50px rgb(0 0 0 / 50%);
+  }
+
+  .tectonic-outline {
+    color: transparent;
+    -webkit-text-stroke: 1px var(--color-tectonic);
+  }
+
+  .mask-linear-fade {
+    mask-image: linear-gradient(to right, black 85%, transparent 100%);
+  }
+
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+
+  .page-container {
+    @apply pt-32 pb-16 px-4 md:pt-32 md:pb-20 md:px-6 mx-auto max-w-7xl;
+  }
+
+  .section-header {
+    @apply mb-12 md:mb-16;
+  }
+
+  .display-title {
+    @apply font-display text-5xl md:text-6xl lg:text-8xl font-bold tracking-tighter mb-4 md:mb-6 leading-[0.9];
+  }
+
+  .body-text {
+    @apply text-white/60 text-base md:text-lg max-w-xl leading-relaxed;
+  }
+
+  .micro-text {
+    @apply text-[10px] md:text-xs uppercase tracking-widest font-bold;
+  }
+
+  .animate-marquee {
+    animation: marquee 40s linear infinite;
+  }
+
+  .pause-on-hover:hover .animate-marquee {
+    animation-play-state: paused;
+  }
+}
+
+@keyframes marquee {
+  0% {
+    transform: translateX(0%);
+  }
+
+  100% {
+    transform: translateX(-50%);
   }
 }


### PR DESCRIPTION
## Refine global typography and add tectonic visual system

### Why?
* **Business Context:** Improve the site's visual identity and readability by introducing brand-aligned typography and tectonic-themed styling primitives.
* **Technical Reasoning:** Centralize fonts, brand colors, and reusable layout/utility classes in the global stylesheet so components can share a consistent design language.

### What?
* **High-Level Overview:** Add external font imports, define font and brand color CSS variables, enhance the `body` base styles, and introduce a set of tectonic utility classes plus marquee animation.
* **Impacted Areas:** Global typography, page layout shells, interactive card-like components, scrollable containers, and any elements using new tectonic utility classes.
* **Key File Changes:**
 * **Modified:** `app/globals.css` - Introduces font imports, font/color CSS variables, updated body base styles, tectonic utility classes, and marquee keyframes.

### How?
* **Implementation:** 
  * Import Inter, Space Grotesk, and Rage Italic fonts and bind them to `--font-sans`, `--font-display`, and `--font-rage` CSS variables plus a `.font-rage` class.
  * Define brand color tokens (`--color-obsidian`, `--color-tectonic`, `--color-slab`, `--color-fracture`) for reuse across components.
  * Enhance `body` with `font-sans`, anti-aliasing, and tectonic-colored text selection styles.
  * Add an `@layer components` block with utility classes for tectonic borders/glow (`.tectonic-border`, `.tectonic-glow`), shadows (`.slab-shadow`), outlined text (`.tectonic-outline`), masking (`.mask-linear-fade`), scrollbar hiding (`.scrollbar-hide`), layout shells (`.page-container`, `.section-header`), typography helpers (`.display-title`, `.body-text`, `.micro-text`), and marquee animation (`.animate-marquee`, `.pause-on-hover`).
  * Define `@keyframes marquee` for horizontal marquee motion.

* **Code Highlights:**
  * `.tectonic-border` / `.tectonic-glow` pair for interactive card hover glow driven by CSS variables for cursor position.
  * `.display-title` and `.body-text` helpers to standardize hero headings and body copy across pages.
  * `.page-container` layout helper to enforce consistent max-width, padding, and spacing for main page sections.
  * `.animate-marquee` and `@keyframes marquee` for horizontally scrolling content strips with pause-on-hover behavior.

### Demo/Screenshots
N/A

### Anything Else?
* **Refactoring:** Consolidates selection and typography base styles on `body` and introduces named CSS variables for brand colors, reducing future duplication and easing theme adjustments.
* **Related:** None explicitly, but intended to support the broader visual revamp of the app.

### What Next?
* **Future Work:** 
  * Apply these utilities across key pages (hero, portfolio, case studies) and ensure consistent behavior in both light and dark modes.
  * Audit components to replace ad-hoc styles with the new tectonic utility classes and color tokens.
* **Dependencies:** 
  * Ensure CSP allows loading fonts from the configured Google Fonts and CDN endpoints.
  * Verify no FOUT/FOIT regressions and that fallbacks render acceptably if external fonts fail to load.